### PR TITLE
Fix invalid preprocessor directives

### DIFF
--- a/Buttons.cpp
+++ b/Buttons.cpp
@@ -116,7 +116,7 @@ void ConfigMenuButtonEventHandler(bool SaturateColor, ButtonActionEnum ButtonAct
     else if (ConfigModeSubStates==CS_MAINCOLOR) {
       #ifdef GRAVITY_COLOR
         ColorMixing(storage.sndProfile[storage.soundFont].mainColor,modification,MAX_BRIGHTNESS, SaturateColor);
-      #else if COLOR_PROFILE
+      #elif defined COLOR_PROFILE
         if (ButtonActionType==SINGLE_CLICK){
           confParseValue(modification, 0, 14, incrementSign);
           modification = value;
@@ -133,7 +133,7 @@ void ConfigMenuButtonEventHandler(bool SaturateColor, ButtonActionEnum ButtonAct
     else if (ConfigModeSubStates==CS_CLASHCOLOR) {
       #ifdef GRAVITY_COLOR
         ColorMixing(storage.sndProfile[storage.soundFont].clashColor,modification,MAX_BRIGHTNESS, SaturateColor);
-      #else if COLOR_PROFILE
+      #elif defined COLOR_PROFILE
         if (ButtonActionType==SINGLE_CLICK){
           confParseValue(modification, 0, 14, incrementSign);
           modification = value;
@@ -149,7 +149,7 @@ void ConfigMenuButtonEventHandler(bool SaturateColor, ButtonActionEnum ButtonAct
     else if (ConfigModeSubStates==CS_BLASTCOLOR) {
       #ifdef GRAVITY_COLOR
         ColorMixing(storage.sndProfile[storage.soundFont].blasterboltColor,modification,MAX_BRIGHTNESS, SaturateColor);
-      #else if COLOR_PROFILE
+      #elif defined COLOR_PROFILE
         if (ButtonActionType==SINGLE_CLICK){
           confParseValue(modification, 0, 14, incrementSign);
           modification = value;

--- a/Config_HW.h
+++ b/Config_HW.h
@@ -43,7 +43,7 @@
   #ifndef SINGLEBUTTON
     #define AUX_BUTTON   4
   #endif
-#else if defined DIYINO_STARDUST_V2 or defined DIYINO_STARDUST_V3
+#elif defined DIYINO_STARDUST_V2 or defined DIYINO_STARDUST_V3
   #define MAIN_BUTTON      12
   #ifndef SINGLEBUTTON
     #define AUX_BUTTON   11 // 2
@@ -86,7 +86,7 @@
 #ifdef DIYINO_PRIME 
   #define MP3_PSWITCH 15 // A1
   #define FTDI_PSWITCH 16 // A2
-#else if defined DIYINO_STARDUST_V2 or defined DIYINO_STARDUST_V3 
+#elif defined DIYINO_STARDUST_V2 or defined DIYINO_STARDUST_V3 
   #define MP3_PSWITCH 17 // A3
   #define FTDI_PSWITCH 16 // A2
 #endif
@@ -106,7 +106,7 @@
     #define LED_RED       3
     #define LED_GREEN       5
     #define LED_BLUE      6
-  #else if defined DIYINO_STARDUST_V2 or defined DIYINO_STARDUST_V3
+  #elif defined DIYINO_STARDUST_V2 or defined DIYINO_STARDUST_V3
     #define LED_RED       5
     #define LED_GREEN       6
     #define LED_BLUE      9
@@ -152,7 +152,7 @@
     #define LS4       9
     #define LS5       10
     #define LS6       11
-  #else if defined DIYINO_STARDUST_V2 or defined DIYINO_STARDUST_V3
+  #elif defined DIYINO_STARDUST_V2 or defined DIYINO_STARDUST_V3
     #define LS1       5
     #define LS2       6
     #define LS3      9
@@ -174,7 +174,7 @@
   #ifdef HARD_ACCENT
     #define ACCENT_LED 14 //A0
   #endif
-#else if defined DIYINO_STARDUST_V2 or defined DIYINO_STARDUST_V3
+#elif defined DIYINO_STARDUST_V2 or defined DIYINO_STARDUST_V3
   #ifdef HARD_ACCENT
     #define ACCENT_LED 14 //A0 is an auxiliary pin on Stardust v2
   #endif

--- a/FX-SaberOS.ino
+++ b/FX-SaberOS.ino
@@ -95,7 +95,7 @@ VectorInt16 prevDeltAccel;
 #if defined LEDSTRINGS
   #ifdef DIYINO_PRIME
     uint8_t ledPins[] = {LS1, LS2, LS3, LS4, LS5, LS6};
-  #else if defined DIYINO_STARDUST_V2 or defined DIYINO_STARDUST_V3
+  #elif defined DIYINO_STARDUST_V2 or defined DIYINO_STARDUST_V3
     uint8_t ledPins[] = {LS1, LS2, LS3};
   #endif
   uint8_t blasterPin;
@@ -107,7 +107,7 @@ extern bool fireblade;
 #if defined PIXELBLADE or defined ADF_PIXIE_BLADE
   #ifdef DIYINO_PRIME
     uint8_t ledPins[] = {LS1, LS2, LS3, LS4, LS5, LS6};
-  #else if defined DIYINO_STARDUST_V2 or defined DIYINO_STARDUST_V3
+  #elif defined DIYINO_STARDUST_V2 or defined DIYINO_STARDUST_V3
     uint8_t ledPins[] = {LS1, LS2, LS3};
   #endif
   WS2812 pixels(NUMPIXELS);
@@ -915,7 +915,7 @@ void loop() {
             // in case of a neopixel blade, show the gravity color on the last 5 pixel of the blade tip
             #ifdef PIXELBLADE
               lightOn(ledPins, -1, currentColor, NUMPIXELS - 5, NUMPIXELS);
-            #else if STAR_LED
+            #elif STAR_LED
             #endif
           #ifdef ADF_PIXIE_BLADE
             if (ConfigModeSubStates == CS_MAINCOLOR) {

--- a/Light.cpp
+++ b/Light.cpp
@@ -73,7 +73,7 @@ bool fireblade=false;
     //#endif
     #define PIXELSTEP 2 // how many pixel to treat as a group to save on processing capability
     static byte heat[NUMPIXELS/PIXELSTEP];
-  #endif ANIBLADE
+  #endif  // ANIBLADE
 #endif  // PIXELBLADE
 
 
@@ -263,7 +263,7 @@ void RampBlade(uint16_t RampDuration, bool DirectionUpDown, int8_t StartPixel=-1
           }
           pixels.sync(); // Sends the data to the LEDs
         }    
-        #endif ANIBLADE
+        #endif  // ANIBLADE
     } // fireblade
     else { //#else
       for (unsigned int i = StartPixel; i < StopPixel; i = StopPixel*(millis()-ignitionStart)/RampDuration) { // turn on/off the number of LEDs that match rap timing
@@ -950,7 +950,7 @@ void pixelblade_KillKey_Enable() {
   #if defined PIXELBLADE or defined ADF_PIXIE_BLADE
     #ifdef PIXELBLADE
       digitalWrite(DATA_PIN,HIGH); // in order not to back-connect GND over the Data pin to the stripes when the Low-Sides disconnect it
-    #else if ADF_PIXIE_BLADE
+    #elif ADF_PIXIE_BLADE
       digitalWrite(PIXIEPIN,HIGH); // in order not to back-connect GND over the Data pin to the stripes when the Low-Sides disconnect it
     #endif
     // cut power to the neopixels stripes by disconnecting their GND signal using the LS pins

--- a/Soundfont.h
+++ b/Soundfont.h
@@ -20,7 +20,7 @@
   #define NR_CONFIGFOLDERFILES 29
   #define NR_JUKEBOXSONGS 0
   #define NR_FILE_SF 30
-#else if defined DIYINO_STARDUST_V2
+#elif defined DIYINO_STARDUST_V2
   #define SOUNDFONT_QUANTITY 3
   #define NR_CONFIGFOLDERFILES 29
   #define NR_JUKEBOXSONGS 0
@@ -94,7 +94,7 @@ void setID(uint16_t id) {
       this->powerOnTime = 700;
       this->powerOffTime = 1500;
       break;
-  #else if DIYINO_STARDUST_V2
+  #elif DIYINO_STARDUST_V2
     default:
     case 0:
       // soundFont directory 01 :
@@ -134,7 +134,7 @@ void setID(uint16_t id) {
     #define SF_BLASTER_NR 4
     #define SF_MENU_NR 1
     #define SF_HUM_NR 1
-  #else if DIYINO_STARDUST_V2 // 18 files per sound font
+  #elif DIYINO_STARDUST_V2 // 18 files per sound font
     #define SF_BOOT_OFFSET 1
     #define SF_POWERON_OFFSET 2
     #define SF_POWEROFF_OFFSET 3


### PR DESCRIPTION
There is no "#else if" preprocessor directive. The correct directive is #elif. "#else if" is treated as #else.

I recommend turning on compiler warnings (File > Preferences > Compiler warnings > All) in order to get helpful notifications of these sorts of issues.