### PR TITLE
Fix Jukebox mode

### DIFF
--- a/FX-SaberOS.ino
+++ b/FX-SaberOS.ino
@@ -474,7 +474,7 @@ Serial.println(configAdress);
   lockupButton.setClickTicks(CLICK);
   lockupButton.setPressTicks(PRESS_CONFIG);
   lockupButton.attachClick(lockupClick);
-  //lockupButton.attachDoubleClick(lockupDoubleClick);
+  lockupButton.attachDoubleClick(lockupDoubleClick);
   lockupButton.attachLongPressStart(lockupLongPressStart);
   lockupButton.attachLongPressStop(lockupLongPressStop);
   lockupButton.attachDuringLongPress(lockupLongPress);

--- a/Light.cpp
+++ b/Light.cpp
@@ -1230,6 +1230,7 @@ void FoCOff(uint8_t pin) {
 
 
 #ifdef JUKEBOX
+#ifndef PIXELBLADE
 void JukeBox_Stroboscope(uint8_t ledPins[]) {
  uint16_t variation = 0;
  uint16_t temp_variation=0;
@@ -1264,10 +1265,12 @@ void JukeBox_Stroboscope(uint8_t ledPins[]) {
   //delay(50);
 }
 #endif
-
+#endif
 
 
 #ifdef JUKEBOX
+#ifdef PIXELBLADE
+ 
 void JukeBox_Stroboscope(cRGB color) {
 
  uint16_t variation = 0;
@@ -1296,7 +1299,7 @@ void JukeBox_Stroboscope(cRGB color) {
 
 }
 #endif
-
+#endif
 
 #ifdef PIXELBLADE
 #ifdef ANIBLADE
@@ -1623,4 +1626,3 @@ void pixelAccentUpdate() {
   accentPixels.sync();
   #endif
 }
-    

--- a/Light.h
+++ b/Light.h
@@ -36,7 +36,11 @@ void lightBlasterEffect(uint8_t ledPins[], uint8_t pixel, uint8_t range, uint16_
 void lightClashEffect(uint8_t ledPins[], cRGB color={0,0,0});
 
 #ifdef JUKEBOX
-  void JukeBox_Stroboscope(uint8_t ledPins[], cRGB color={0,0,0});
+  #ifdef PIXELBLADE
+    void JukeBox_Stroboscope(cRGB color={0,0,0});
+  #else
+    void JukeBox_Stroboscope(unit8_t ledPins[], cRGB color={0,0,0});
+  #endif
 #endif
 void pixelblade_KillKey_Enable();
 void pixelblade_KillKey_Disable();


### PR DESCRIPTION
These changes will fix jukebox mode by allowing jukebox mode to be defined when pixelblade is defined, and also re-enable clash button double-click, which is used to select jukebox mode when 2 buttons are enabled.