### PR TITLE
adds config option to fix sound looping issues when using clone DFPlayer

### DIFF
--- a/Config_HW.h
+++ b/Config_HW.h
@@ -186,7 +186,10 @@
 #define DFPLAYER_TX     7
 #define SPK1        20 //A6
 #define SPK2        21 //A7
-
+/*
+ * Uncomment to correct sound issues (e.g. incorrectly looping sounds) when using a DFPlayer clone chip such as the MH2024K-24SS
+ */
+//#define DFPLAYER_CLONE
 
 
 

--- a/FX-SaberOS.ino
+++ b/FX-SaberOS.ino
@@ -496,6 +496,9 @@ Serial.println(configAdress);
   /***** DF PLAYER INITIALISATION  *****/
   InitDFPlayer();
   delay(200);
+  #ifdef DFPLAYER_CLONE
+  delay(800); // clone chip requires more time to initialize
+  #endif   
  // according to debug on 3.11.2017, these 2 lines below cause the sporadic disable of sound. For audio tracker they are not strictly needed.
   //pinMode(SPK1, INPUT);
   //pinMode(SPK2, INPUT);
@@ -1340,6 +1343,10 @@ void HumRelaunch() {
 
 void SinglePlay_Sound(uint8_t track) {
   dfplayer.playPhysicalTrack(track);
+  #ifdef DFPLAYER_CLONE
+  delay(100); 
+  dfplayer.setSingleLoop(false); // fixes incorrect looping of certain sounds on clone chips
+  #endif
 }
 
 void LoopPlay_Sound(uint8_t track) {


### PR DESCRIPTION
Uncomment the DFPLAYER_CLONE  option in Config_HW to correct sound issues (incorrectly looping sounds and/or boot sound not playing) when using a DFPlayer clone chip such as the MH2024K-24SS