### PR TITLE
ensures battery check code is no longer loaded if the BATTERY_CHECK flag is disabled

### DIFF
--- a/ConfigMenu.cpp
+++ b/ConfigMenu.cpp
@@ -43,7 +43,9 @@ extern void Disable_MP3(bool mp3_off);
 extern void confParseValue(uint16_t variable, uint16_t min, uint16_t max,
     short int multiplier);
 extern uint8_t GravityVector();
+#ifdef BATTERY_CHECK
 extern void BatLevel_ConfigEnter();
+#endif
 
 extern struct StoreStruct {
   // This is for mere detection if they are our settings
@@ -187,12 +189,14 @@ void NextConfigState(){
         SinglePlay_Sound(29);
         delay(500);
         break;   
+#ifdef BATTERY_CHECK        
       case CS_BATTERYLEVEL: 
         #if defined LS_FSM
           Serial.print(F("Display battery level"));
         #endif        
         BatLevel_ConfigEnter();
         break;   
+#endif        
       case CS_STORAGEACCESS: 
         #if defined LS_FSM
           Serial.print(F("USB Media storage access"));

--- a/FX-SaberOS.ino
+++ b/FX-SaberOS.ino
@@ -968,9 +968,11 @@ void loop() {
               or abs(curDeltAccel.x) > storage.sndProfile[storage.soundFont].swingSensitivity)) {
                 SinglePlay_Sound(soundFont.getSwing((storage.soundFont)*NR_FILE_SF));
               }
+#ifdef BATTERY_CHECK             
     else if (ConfigModeSubStates == CS_BATTERYLEVEL) {
       MonitorBattery();
     }
+#endif    
   } //END CONFIG MODE HANDLER
 
   /*//////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1518,6 +1520,8 @@ void Disable_MP3(bool mp3_off) {
   }
   
 }
+
+#ifdef BATTERY_CHECK
 // ====================================================================================
 // ===                         BATTERY CHECKING FUNCTIONS                           ===
 // ====================================================================================
@@ -1586,7 +1590,7 @@ void MonitorBattery() {
     //Serial.println(getBandgap());
   #endif
 }
- 
+
 // Code courtesy of "Coding Badly" and "Retrolefty" from the Arduino forum
 // results are Vcc * 100
 // So for example, 5V would be 500.
@@ -1602,3 +1606,4 @@ int getBandgap ()
    //Serial.print("battery voltage: ");Serial.println(results);
    return results;
   } // end of getBandgap
+#endif


### PR DESCRIPTION
Battery check code was always loaded, irrespective of the BATTERY_CHECK flag. This has been corrected - now this code does not load if BATTERY_CHECK is commented out in Config_HW, which saves precious program space that can be used to enable other features if one does not wish to use the battery check functionality.